### PR TITLE
Fix logout function and summary completeness check

### DIFF
--- a/idus-backend/workpoints/views.py
+++ b/idus-backend/workpoints/views.py
@@ -239,7 +239,7 @@ class WorkPointReportView(APIView, UserPermissionMixin, ReportMixin):
                 "total_worked": str(total_worked),
                 "remaining_hours": str(remaining),
                 "extra_hours": str(extra),
-                "is_complete": remaining == timedelta(),
+                "is_complete": remaining == 0,
             }
         )
 
@@ -293,6 +293,9 @@ class DailySummaryView(APIView, UserPermissionMixin, ReportMixin):
         total_worked = calculate_worked_hours(
             grouped_points, start_date=today, end_date=today, scale=scale
         )
+        remaining = calculate_remaining_hours(
+            total_worked, user.work_schedule, grouped_points
+        )
         return Response(
             {
                 "date": today.strftime("%d/%m/%Y"),
@@ -305,6 +308,6 @@ class DailySummaryView(APIView, UserPermissionMixin, ReportMixin):
                     for p in points
                 ],
                 "total_worked": str(total_worked),
-                "is_complete": "",
+                "is_complete": remaining == 0,
             }
         )

--- a/idus-frontend/src/app/dashboard/page.js
+++ b/idus-frontend/src/app/dashboard/page.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { fetchUsers } from "../api/user";
+import { logout as removeTokens } from "../api/auth";
 
 export default function Dashboard() {
   const [users, setUsers] = useState([]);
@@ -41,7 +42,7 @@ export default function Dashboard() {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("authToken");
+    removeTokens();
     router.push("/");
   };
 


### PR DESCRIPTION
## Summary
- correctly remove auth cookies on logout
- compute `is_complete` for daily summary and reports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6843027bfa688333bb91e8d5f6838880