### PR TITLE
Fix duplicate last name in UserInfo component

### DIFF
--- a/idus-frontend/src/app/components/UserInfo.js
+++ b/idus-frontend/src/app/components/UserInfo.js
@@ -2,8 +2,7 @@ export function UserInfo({ user }) {
   return (
     <div className="mb-8 bg-gray-50 p-4 rounded-lg shadow">
       <p className="text-lg text-gray-800">
-        <span className="font-semibold">Nome Completo:</span> {user.name}{" "}
-        {user.last_name}
+        <span className="font-semibold">Nome Completo:</span> {user.name}
       </p>
       <p className="text-lg text-gray-800">
         <span className="font-semibold">CPF:</span> {user.cpf}

--- a/idus-frontend/src/app/components/UserInfo.test.js
+++ b/idus-frontend/src/app/components/UserInfo.test.js
@@ -4,8 +4,7 @@ import { UserInfo } from './UserInfo';
 describe('UserInfo', () => {
   it('exibe informacoes do usuario', () => {
     const user = {
-      name: 'Joao',
-      last_name: 'Silva',
+      name: 'Joao Silva',
       cpf: '123.456.789-00',
       email: 'joao@example.com',
       birthDate: '1990-01-01',


### PR DESCRIPTION
## Summary
- fix layout bug in `UserInfo` where last name was shown twice
- update associated unit test

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684328184360833392a286020507b946