### PR TITLE
Fix ErrorMessage to display single messages

### DIFF
--- a/idus-frontend/src/app/components/ErrorMessage.js
+++ b/idus-frontend/src/app/components/ErrorMessage.js
@@ -1,13 +1,19 @@
-const ErrorMessage = ({ errors }) => {
-  if (!errors) return null;
+const ErrorMessage = ({ errors, message }) => {
+  if (!errors && !message) return null;
+
+  const singleMessage = message || (typeof errors === "string" ? errors : null);
+
+  if (singleMessage) {
+    return <p className="mt-6 text-red-600">{singleMessage}</p>;
+  }
 
   if (typeof errors === "object" && !Array.isArray(errors)) {
     return (
       <div className="mt-6 text-red-600">
         <ul className="list-disc pl-5">
-          {Object.entries(errors).map(([field, message]) => (
+          {Object.entries(errors).map(([field, errorMessage]) => (
             <li key={field}>
-              <strong>{field}:</strong> {message}
+              <strong>{field}:</strong> {errorMessage}
             </li>
           ))}
         </ul>
@@ -15,7 +21,6 @@ const ErrorMessage = ({ errors }) => {
     );
   }
 
- 
   return null;
 };
 


### PR DESCRIPTION
## Summary
- support displaying a single message in `ErrorMessage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843364d38648333888ed2e5eb53c265