### PR TITLE
Use env var for API URL

### DIFF
--- a/idus-frontend/.env.example
+++ b/idus-frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000/api

--- a/idus-frontend/README.md
+++ b/idus-frontend/README.md
@@ -7,6 +7,18 @@ Este é o frontend do projeto **idus**, desenvolvido com **Next.js**. Ele se con
 - **Node.js** (versão 18 ou superior)
 - **Docker** (opcional, para rodar com container)
 
+## **Variáveis de Ambiente**
+
+Copie o arquivo `.env.example` para `.env` e ajuste o valor abaixo, caso
+necessário:
+
+```env
+NEXT_PUBLIC_API_URL=http://localhost:8000/api
+```
+
+Essa variável define a URL base utilizada pelo frontend para se comunicar com a
+API backend.
+
 ## **Como Rodar o Projeto**
 
 ### **1. Usando Docker (Recomendado)**

--- a/idus-frontend/src/app/api/config.js
+++ b/idus-frontend/src/app/api/config.js
@@ -1,1 +1,1 @@
-export const BASE_URL = "http://127.0.0.1:8000/api";
+export const BASE_URL = process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
## Summary
- configure frontend API base URL via NEXT_PUBLIC_API_URL
- document environment variable in frontend README
- add `.env.example` for frontend

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68433be82f008333a8ab58f599364713