### PR TITLE
Use HttpOnly cookies for JWT

### DIFF
--- a/idus-frontend/package-lock.json
+++ b/idus-frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "idus-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "js-cookie": "^3.0.5",
         "leaflet": "^1.9.4",
         "next": "15.0.3",
         "react": "^18.3.0",
@@ -6942,16 +6941,7 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
+      },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/idus-frontend/package.json
+++ b/idus-frontend/package.json
@@ -10,7 +10,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "js-cookie": "^3.0.5",
     "leaflet": "^1.9.4",
     "next": "15.0.3",
     "react": "^18.3.0",

--- a/idus-frontend/src/app/api/auth.js
+++ b/idus-frontend/src/app/api/auth.js
@@ -1,105 +1,48 @@
 import { BASE_URL } from "./config";
-import Cookies from "js-cookie";
-
-export function saveTokens({ access, refresh }) {
-  if (typeof window !== "undefined") {
-
-    if (access) Cookies.set("access_token", access, { expires: 7, path: "/" });
-    if (refresh)
-      Cookies.set("refresh_token", refresh, { expires: 30, path: "/" });
-  }
-}
-
-export const getAccessToken = () => {
-  if (typeof window !== "undefined") {
-    return Cookies.get("access_token");
-  }
-  return null;
-};
-
-export const getRefreshToken = () => {
-  if (typeof window !== "undefined") {
-    return Cookies.get("refresh_token");
-  }
-  return null;
-};
-
-export const clearTokens = () => {
-  Cookies.remove("access_token", { path: "/" });
-  Cookies.remove("refresh_token", { path: "/" });
-};
 
 /**
- * Renovar token de acesso usando o token de refresh.
- * @returns {Promise<string>} Novo token de acesso
+ * Since the backend now manages authentication tokens using HttpOnly cookies,
+ * the frontend no longer stores or directly accesses these values. All
+ * requests that require authentication should include `credentials: "include"`
+ * so the cookies are sent along.
  */
+
 export async function refreshAccessToken() {
-  const refreshToken = getRefreshToken();
+  const response = await fetch(`${BASE_URL}/auth/jwt/refresh/`, {
+    method: "POST",
+    credentials: "include",
+  });
 
-  if (!refreshToken) {
-    clearTokens();
-    if (typeof window !== "undefined") {
-      window.location.href = "/";
-    }
-    throw new Error("Token de refresh não encontrado. Faça login novamente.");
+  if (!response.ok) {
+    throw new Error("Falha ao renovar o token.");
   }
 
-  try {
-    const response = await fetch(`${BASE_URL}/auth/jwt/refresh/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh: refreshToken }),
-    });
-
-    if (!response.ok) {
-      clearTokens();
-      if (typeof window !== "undefined") {
-        window.location.href = "/";
-      }
-      throw new Error("Falha ao renovar o token. Faça login novamente.");
-    }
-
-    const data = await response.json();
-    saveTokens({ access: data.access, refresh: refreshToken });
-    return data.access;
-  } catch (error) {
-    console.error("Erro ao renovar token:", error.message);
-    clearTokens();
-    if (typeof window !== "undefined") {
-      window.location.href = "/";
-    }
-    throw error;
-  }
+  return await response.json();
 }
 
-/**
- * Login do usuário e obtenção de tokens JWT.
- * @param {Object} credentials { cpf, password }
- * @returns {Promise<Object>} Objeto com tokens { access, refresh }
- */
 export async function login(credentials) {
-  try {
-    const response = await fetch(`${BASE_URL}/auth/jwt/create/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(credentials),
-    });
+  const response = await fetch(`${BASE_URL}/auth/jwt/create/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(credentials),
+  });
 
-    if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || "Erro no login.");
-    }
-
-    const tokens = await response.json();
-    saveTokens(tokens);
-    return tokens;
-  } catch (error) {
-    console.error("Erro no login:", error.message);
-    throw error;
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.detail || "Erro no login.");
   }
+
+  return await response.json();
 }
 
-/**
- * Logout do usuário (limpa os tokens armazenados).
- */
-export const logout = () => clearTokens();
+export async function logout() {
+  try {
+    await fetch(`${BASE_URL}/auth/logout/`, {
+      method: "POST",
+      credentials: "include",
+    });
+  } catch (error) {
+    console.error("Erro no logout:", error.message);
+  }
+}

--- a/idus-frontend/src/app/api/user.js
+++ b/idus-frontend/src/app/api/user.js
@@ -1,5 +1,5 @@
 import { BASE_URL } from "./config";
-import { getAccessToken, refreshAccessToken } from "./auth";
+import { refreshAccessToken } from "./auth";
 
 /**
  * Requisição genérica para a API.
@@ -9,28 +9,25 @@ import { getAccessToken, refreshAccessToken } from "./auth";
  * @returns {Promise<Object>} Resposta da API em JSON
  */
 async function apiRequest(endpoint, method, body = null) {
-  let token = getAccessToken();
-
   const headers = {
     "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
   };
 
   try {
     let response = await fetch(`${BASE_URL}${endpoint}`, {
       method,
       headers,
+      credentials: "include",
       body: body ? JSON.stringify(body) : null,
     });
 
     if (response.status === 401) {
       console.warn("Token expirado. Tentando renovar...");
-      token = await refreshAccessToken();
-      headers.Authorization = `Bearer ${token}`;
-
+      await refreshAccessToken();
       response = await fetch(`${BASE_URL}${endpoint}`, {
         method,
         headers,
+        credentials: "include",
         body: body ? JSON.stringify(body) : null,
       });
     }
@@ -92,11 +89,7 @@ export const getWorkPointReport = (userId, { startDate, endDate }) =>
   );
 
 export const downloadWorkPointPDF = async (userId, { startDate, endDate }) => {
-  const token = getAccessToken();
-
-  const headers = {
-    Authorization: `Bearer ${token}`,
-  };
+  const headers = {};
 
   try {
     const response = await fetch(
@@ -104,6 +97,7 @@ export const downloadWorkPointPDF = async (userId, { startDate, endDate }) => {
       {
         method: "GET",
         headers,
+        credentials: "include",
       }
     );
 

--- a/idus-frontend/src/app/dashboard/page.js
+++ b/idus-frontend/src/app/dashboard/page.js
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { fetchUsers } from "../api/user";
-import { logout as removeTokens } from "../api/auth";
+import { logout } from "../api/auth";
 
 export default function Dashboard() {
   const [users, setUsers] = useState([]);
@@ -41,8 +41,8 @@ export default function Dashboard() {
     router.push("/user/create");
   };
 
-  const handleLogout = () => {
-    removeTokens();
+  const handleLogout = async () => {
+    await logout();
     router.push("/");
   };
 

--- a/idus-frontend/src/app/user/create/page.js
+++ b/idus-frontend/src/app/user/create/page.js
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
-import { getAccessToken } from "../../api/auth";
 import { createUser } from "../../api/user";
 import CreateUserForm from "../../components/CreateUserForm";
 import ErrorMessage from "../../components/ErrorMessage";
@@ -23,13 +22,6 @@ const CreateUser = () => {
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const router = useRouter();
-
-  useEffect(() => {
-    const token = getAccessToken();
-    if (!token) {
-      router.push("/");
-    }
-  }, [router]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- update frontend auth API to rely on HttpOnly cookies
- send credentials with API requests instead of manual tokens
- adjust user creation, dashboard and package files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433e024e508333a8f529d8bb7a5c17