### PR TITLE
Restrict user creation to admins

### DIFF
--- a/idus-backend/users/tests.py
+++ b/idus-backend/users/tests.py
@@ -55,6 +55,21 @@ def test_create_user(client, admin_user):
     assert response.status_code == 201
     assert response.json()["detail"] == "Usuário criado com sucesso."
 
+
+def test_create_user_forbidden(client, user):
+    client.force_authenticate(user)
+    payload = {
+        "cpf": "88844477735",
+        "email": "forbidden@example.com",
+        "first_name": "Forbidden",
+        "last_name": "User",
+        "password": "password",
+        "role": "common",
+        "scale": "5x1",
+    }
+    response = client.post("/api/users/create/", payload, format="json")
+    assert response.status_code == 403
+
 # UserInfoView
 
 def test_info_self(client, user):

--- a/idus-backend/users/views.py
+++ b/idus-backend/users/views.py
@@ -1,6 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework import status
 from rest_framework.generics import UpdateAPIView, DestroyAPIView
 from django.shortcuts import get_object_or_404
@@ -12,7 +12,7 @@ from .serializers import UserSerializer, UserSerializerInfo
 class UserCreateView(APIView):
     """View para criação de novos usuários."""
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAdminUser]
 
     def post(self, request, *args, **kwargs):
         serializer = UserSerializer(data=request.data)


### PR DESCRIPTION
## Summary
- only administrators may create new users
- cover new restriction with test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684343c0449483339deac60304de259d