### PR TITLE
Restrict user deletion

### DIFF
--- a/idus-backend/users/tests.py
+++ b/idus-backend/users/tests.py
@@ -128,3 +128,16 @@ def test_delete_user(client, admin_user, user):
     response = client.delete(f"/api/users/delete/{user.id}/")
     assert response.status_code == 204
     assert User.objects.filter(id=user.id).count() == 0
+
+
+def test_delete_self(client, user):
+    client.force_authenticate(user)
+    response = client.delete(f"/api/users/delete/{user.id}/")
+    assert response.status_code == 204
+    assert User.objects.filter(id=user.id).count() == 0
+
+
+def test_delete_other_forbidden(client, user, other_user):
+    client.force_authenticate(user)
+    response = client.delete(f"/api/users/delete/{other_user.id}/")
+    assert response.status_code == 403

--- a/idus-backend/users/views.py
+++ b/idus-backend/users/views.py
@@ -115,6 +115,17 @@ class UserDeleteView(DestroyAPIView):
     queryset = User.objects.all()
     lookup_field = "id"
 
+    def get_object(self):
+        """Permite que usuários comuns deletem apenas o próprio cadastro."""
+        obj = super().get_object()
+
+        if not self.request.user.is_staff and obj != self.request.user:
+            raise PermissionDenied(
+                {"detail": "Você não tem permissão para deletar este usuário."}
+            )
+
+        return obj
+
     def destroy(self, request, *args, **kwargs):
         user = self.get_object()
         self.perform_destroy(user)


### PR DESCRIPTION
## Summary
- limit `UserDeleteView` to allow non-admins to delete only themselves
- exercise new `get_object` permissions with tests

## Testing
- `pytest -q idus-backend`

------
https://chatgpt.com/codex/tasks/task_e_6843452f2c0c8333b4854903bd29b9eb