### PR TITLE
Make default admin optional

### DIFF
--- a/idus-backend/.env.example
+++ b/idus-backend/.env.example
@@ -8,4 +8,6 @@ DATABASE_PORT=5432
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 ACCESS_TOKEN_LIFETIME=60
+# Set to "true" to create a default admin user during migrations
+CREATE_DEFAULT_ADMIN=false
 

--- a/idus-backend/README.md
+++ b/idus-backend/README.md
@@ -82,9 +82,10 @@ Antes de começar, você precisará ter as seguintes ferramentas instaladas:
    http://127.0.0.1:8000
    ```
 
-3. **Criação de Superusuário Padrão:**
+3. **Criação de Superusuário Padrão (Opcional):**
 
-   - Ao executar `python manage.py migrate`, um superusuário com CPF `39416362000` é criado automaticamente, com o seguinte login:
+   - Caso deseje criar automaticamente um usuário administrador de teste, defina a variável `CREATE_DEFAULT_ADMIN=true` no arquivo `.env` e execute `python manage.py migrate`.
+     O usuário criado terá as seguintes credenciais:
      ```plaintext
      CPF: 39416362000
      Senha: admin123

--- a/idus-backend/users/signals.py
+++ b/idus-backend/users/signals.py
@@ -1,10 +1,15 @@
 from django.db.models.signals import post_migrate
 from django.dispatch import receiver
+from decouple import config
 from .models import User
 
 
 @receiver(post_migrate)
 def create_default_superuser(sender, **kwargs):
+    """Create a default admin user if the environment allows it."""
+    if not config("CREATE_DEFAULT_ADMIN", default=False, cast=bool):
+        return
+
     if not User.objects.filter(cpf="39416362000").exists():
         User.objects.create_superuser(
             cpf="39416362000",
@@ -13,5 +18,5 @@ def create_default_superuser(sender, **kwargs):
             last_name="User",
             birth_date="1980-01-01",
             password="admin123",
-            role="admin"
+            role="admin",
         )


### PR DESCRIPTION
## Summary
- gate admin creation with CREATE_DEFAULT_ADMIN flag
- document how to enable optional admin
- note new env variable in example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843465884148333b08634bf4dc1bfe4