### PR TITLE
Fix WorkPoint __str__ and add unit test

### DIFF
--- a/idus-backend/workpoints/models.py
+++ b/idus-backend/workpoints/models.py
@@ -37,5 +37,5 @@ class WorkPoint(models.Model):
 
     def __str__(self):
         return (
-            f"{self.user.username} - {self.type} em {self.timestamp} ({self.weekday})"
+            f"{self.user.cpf} - {self.type} em {self.timestamp} ({self.weekday})"
         )

--- a/idus-backend/workpoints/tests.py
+++ b/idus-backend/workpoints/tests.py
@@ -177,3 +177,11 @@ def test_permission_admin_access_any_report(db, client, admin_user, other_user):
         f"/api/workpoints/report/{other_user.id}/?start_date=2024-11-29&end_date=2024-11-29"
     )
     assert response.status_code == 200
+
+
+def test_workpoint_str_representation(db, user, workpoint_model):
+    timestamp = timezone.make_aware(datetime(2024, 11, 29, 8, 0, 0))
+    point = workpoint_model.objects.create(user=user, timestamp=timestamp, type="in")
+
+    expected = f"{user.cpf} - in em {point.timestamp} ({point.weekday})"
+    assert str(point) == expected


### PR DESCRIPTION
## Summary
- fix WorkPoint string representation to use user CPF
- add regression test for `str(WorkPoint)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434afc3d3c8333b69ee48e485c9381