### PR TITLE
Fix timezone check in manual point registration

### DIFF
--- a/idus-backend/workpoints/views.py
+++ b/idus-backend/workpoints/views.py
@@ -181,9 +181,14 @@ class WorkPointViewSet(viewsets.ModelViewSet, UserPermissionMixin):
             )
 
         try:
-            aware_timestamp = make_aware(
-                datetime.fromisoformat(timestamp), pytz.timezone("America/Sao_Paulo")
-            )
+            parsed_timestamp = datetime.fromisoformat(timestamp)
+            if parsed_timestamp.tzinfo is None or parsed_timestamp.tzinfo.utcoffset(parsed_timestamp) is None:
+                aware_timestamp = make_aware(
+                    parsed_timestamp,
+                    pytz.timezone("America/Sao_Paulo"),
+                )
+            else:
+                aware_timestamp = parsed_timestamp
         except ValueError:
             return Response(
                 {"detail": "Timestamp inválido. Use o formato ISO 8601."},


### PR DESCRIPTION
## Summary
- avoid calling `make_aware` on already-aware datetimes in `register_point_manual`

## Testing
- `pip install -r idus-backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434e2d89e0833393efde72ff57530a