### PR TITLE
Move point registration under user view

### DIFF
--- a/idus-backend/workpoints/tests.py
+++ b/idus-backend/workpoints/tests.py
@@ -97,7 +97,7 @@ def test_register_point_manual_invalid(db, user, client):
     invalid_timestamp = "2024-11-31T09:00:00"
 
     response = client.post(
-        f"/api/workpoints/{user.id}/register-point-manual/",
+        f"/api/users/{user.id}/workpoints/register-point-manual/",
         {"timestamp": invalid_timestamp},
         format="json",
     )

--- a/idus-backend/workpoints/urls.py
+++ b/idus-backend/workpoints/urls.py
@@ -5,6 +5,7 @@ from .views import (
     DailySummaryView,
     WorkPointReportView,
     WorkPointPDFReportView,
+    UserWorkPointView,
 )
 
 
@@ -22,13 +23,13 @@ urlpatterns = [
     ),
     path("workpoints/report/", WorkPointReportView.as_view(), name="workpoint-report"),
     path(
-        "workpoints/<uuid:id>/register-point/",
-        WorkPointViewSet.as_view({"post": "register_point"}),
+        "users/<uuid:user_id>/workpoints/register-point/",
+        UserWorkPointView.as_view({"post": "register_point"}),
         name="register-point",
     ),
     path(
-        "workpoints/<uuid:id>/register-point-manual/",
-        WorkPointViewSet.as_view({"post": "register_point_manual"}),
+        "users/<uuid:user_id>/workpoints/register-point-manual/",
+        UserWorkPointView.as_view({"post": "register_point_manual"}),
         name="register-point-manual",
     ),
     path(


### PR DESCRIPTION
## Summary
- route user-specific workpoint registration through `UserWorkPointView`
- add `PointCreationMixin` and new view class for registration
- update URL routes and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843523f40b88333a003a5d3badd68a6