### PR TITLE
Add root env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+SECRET_KEY=django-insecure-f55x+z^!6gcz52*w7%o7n5vt58ghciv#9@2epuk=)ug*##rcac
+DEBUG=True
+DATABASE_NAME=idusdb
+DATABASE_USER=idususer
+DATABASE_PASSWORD=iduspass
+DATABASE_HOST=db
+DATABASE_PORT=5432
+CORS_ALLOWED_ORIGINS=http://localhost,http://127.0.0.1:3000

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Este projeto consiste em um sistema com backend baseado em Django Rest Framework
    - **Backend API**: [http://localhost:8000/api/](http://localhost:8000/api/)
 
 4. **Personalize suas Configurações**
-   Se quiser algo diferente, abra o arquivo `.env` e deixe tudo do seu jeitinho 😉.
+   Primeiro, copie o arquivo `.env.example` para `.env` e depois ajuste os valores conforme desejar 😉.
 
 ## **Estrutura de Serviços**
 
@@ -47,7 +47,7 @@ Este projeto consiste em um sistema com backend baseado em Django Rest Framework
 
 ## **Como Personalizar**
 
-Se precisar ajustar alguma configuração, como variáveis de ambiente, edite o arquivo `.env` localizado na raiz do projeto. Exemplo:
+Se precisar ajustar alguma configuração, copie primeiro o arquivo `.env.example` para `.env` e edite-o com os valores desejados. Exemplo:
 
 ```env
 SECRET_KEY=django-insecure-f55x+z^!6gcz52*w7%o7n5vt58ghciv#9@2epuk=)ug*##rcac

--- a/idus-backend/workpoints/tests.py
+++ b/idus-backend/workpoints/tests.py
@@ -111,7 +111,7 @@ def test_register_point_manual_timezone_aware(db, user, client):
     aware_timestamp = "2024-11-29T09:00:00-03:00"
 
     response = client.post(
-        f"/api/workpoints/{user.id}/register-point-manual/",
+        f"/api/users/{user.id}/workpoints/register-point-manual/",
         {"timestamp": aware_timestamp},
         format="json",
     )


### PR DESCRIPTION
## Summary
- add a root `.env.example`
- note `.env.example` copy step in README
- fix path in timezone-aware point registration test

## Testing
- `pytest -q`
- `npm test --if-present`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68435bd9c59c8333bf6810d9e36d9abe