### PR TITLE
Make SECRET_KEY mandatory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-SECRET_KEY=django-insecure-f55x+z^!6gcz52*w7%o7n5vt58ghciv#9@2epuk=)ug*##rcac
+# Generate your own unique Django secret key and set it here
+SECRET_KEY=
 DEBUG=True
 DATABASE_NAME=idusdb
 DATABASE_USER=idususer

--- a/idus-backend/README.md
+++ b/idus-backend/README.md
@@ -314,6 +314,12 @@ A documentação completa da API, gerada automaticamente pelo **DRF Spectacular*
 | POST   | `/workpoints/<id>/register-point/` | Registrar ponto de trabalho             |
 | GET    | `/workpoints/report/<id>/`         | Obter relatório de pontos de trabalho   |
 
+## Variáveis de Ambiente
+
+Defina uma chave secreta exclusiva antes de iniciar o projeto. Copie o arquivo
+`.env.example` para `.env` e edite o valor de `SECRET_KEY` com a sua própria
+chave.
+
 ## Testes
 
 1. Para rodar os testes automatizados:

--- a/idus-backend/idus_backend/settings.py
+++ b/idus-backend/idus_backend/settings.py
@@ -6,10 +6,7 @@ from decouple import config
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-SECRET_KEY = config(
-    "SECRET_KEY",
-    default="django-insecure-f55x+z^!6gcz52*w7%o7n5vt58ghciv#9@2epuk=)ug*##rcac",
-)
+SECRET_KEY = config("SECRET_KEY")
 
 DEBUG = config("DEBUG", default=False, cast=bool)
 


### PR DESCRIPTION
## Summary
- read SECRET_KEY solely from environment in backend settings
- note SECRET_KEY requirement in backend docs
- clarify SECRET_KEY placeholder in root `.env.example`

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68487713b6a48333979098479c64dc6e