### PR TITLE
Improve PDF table header printing

### DIFF
--- a/idus-backend/workpoints/templates/workpoints/report.html
+++ b/idus-backend/workpoints/templates/workpoints/report.html
@@ -50,8 +50,12 @@
           page-break-inside: auto;
         }
 
+        thead {
+          display: table-header-group;
+        }
+
         tr {
-          page-break-inside: avoid;
+          page-break-inside: auto;
         }
 
         th, td {


### PR DESCRIPTION
## Summary
- keep table headers visible on each PDF page
- allow rows to break across pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: decouple, rest_framework)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6798af083339c52828c647d2d29