### PR TITLE
Add localStorage token handling and bearer auth

### DIFF
--- a/idus-frontend/src/app/api/user.js
+++ b/idus-frontend/src/app/api/user.js
@@ -13,21 +13,28 @@ async function apiRequest(endpoint, method, body = null) {
     "Content-Type": "application/json",
   };
 
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
   try {
     let response = await fetch(`${BASE_URL}${endpoint}`, {
       method,
       headers,
-      credentials: "include",
       body: body ? JSON.stringify(body) : null,
     });
 
     if (response.status === 401) {
       console.warn("Token expirado. Tentando renovar...");
-      await refreshAccessToken();
+      const data = await refreshAccessToken();
+      if (data.access) {
+        headers["Authorization"] = `Bearer ${data.access}`;
+      }
       response = await fetch(`${BASE_URL}${endpoint}`, {
         method,
         headers,
-        credentials: "include",
         body: body ? JSON.stringify(body) : null,
       });
     }
@@ -90,6 +97,11 @@ export const getWorkPointReport = (userId, { startDate, endDate }) =>
 
 export const downloadWorkPointPDF = async (userId, { startDate, endDate }) => {
   const headers = {};
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
 
   try {
     const response = await fetch(
@@ -97,7 +109,6 @@ export const downloadWorkPointPDF = async (userId, { startDate, endDate }) => {
       {
         method: "GET",
         headers,
-        credentials: "include",
       }
     );
 

--- a/idus-frontend/src/app/api/user.test.js
+++ b/idus-frontend/src/app/api/user.test.js
@@ -4,6 +4,7 @@ describe('api/user', () => {
   beforeEach(() => {
     fetch.mockClear();
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
+    localStorage.setItem('access_token', 'token');
     jest.resetModules();
   });
 
@@ -17,8 +18,10 @@ describe('api/user', () => {
     const data = await listUsers();
     expect(fetch).toHaveBeenCalledWith('http://localhost/users/list/', {
       method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
       body: null,
     });
     expect(data).toEqual({ result: 'ok' });
@@ -34,8 +37,10 @@ describe('api/user', () => {
     const data = await updateUser(5, { name: 'test' });
     expect(fetch).toHaveBeenCalledWith('http://localhost/users/update/5/', {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
       body: JSON.stringify({ name: 'test' }),
     });
     expect(data).toEqual({ done: true });


### PR DESCRIPTION
## Summary
- persist login tokens in localStorage
- refresh tokens using saved refresh token
- attach `Authorization` header to API calls
- clear stored tokens on logout
- adjust tests to mock saved tokens

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68531065e7688333a636891823a7c39f